### PR TITLE
Fix the use of both control and normal connections

### DIFF
--- a/lib/byebug/remote.rb
+++ b/lib/byebug/remote.rb
@@ -55,8 +55,8 @@ module Byebug
 
       @control_thread = DebugThread.new do
         while (session = server.accept)
-          handler.interface = RemoteInterface.new(session)
-          ControlCommandProcessor.new(handler.interface).process_commands
+          interface = RemoteInterface.new(session)
+          ControlCommandProcessor.new(interface).process_commands
         end
       end
 


### PR DESCRIPTION
It seems just a typo in this commit: https://github.com/deivid-rodriguez/byebug/commit/90cdfcc9cee8ba6362bad2185390cbe4fa85845d

Using the same var in the two places kills one connect when another is opened. Detected the problem while using sublime-ruby-debugger.

I just changed to use a local var (igual was before that commit), and it fixes everething for me.